### PR TITLE
feat: rename repository from agentflow to AgenticGoKit

### DIFF
--- a/cmd/agentcli/cmd/cache.go
+++ b/cmd/agentcli/cmd/cache.go
@@ -10,7 +10,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/core"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/agentcli/cmd/create.go
+++ b/cmd/agentcli/cmd/create.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kunalkushwaha/agentflow/internal/scaffold"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/scaffold"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/agentcli/cmd/mcp.go
+++ b/cmd/agentcli/cmd/mcp.go
@@ -9,7 +9,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/core"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/agentcli/cmd/memory.go
+++ b/cmd/agentcli/cmd/memory.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/core"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/agentcli/cmd/memory_test.go
+++ b/cmd/agentcli/cmd/memory_test.go
@@ -5,7 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kunalkushwaha/agentflow/core"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
 )
 
 func TestMemoryDebugger_ShowOverview(t *testing.T) {

--- a/cmd/agentcli/cmd/trace.go
+++ b/cmd/agentcli/cmd/trace.go
@@ -16,7 +16,7 @@ import (
 	"text/tabwriter"
 	"time"
 
-	agentflow "github.com/kunalkushwaha/agentflow/core" // Import core types
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/core" // Import core types
 
 	"github.com/spf13/cobra"
 )
@@ -134,21 +134,21 @@ func displayTrace(sessionID, filter string) {
 		os.Exit(1)
 	}
 
-	// Convert to agentflow.TraceEntry
-	var traceEntries []agentflow.TraceEntry
+	// Convert to agenticgokit.TraceEntry
+	var traceEntries []agenticgokit.TraceEntry
 	for _, je := range jsonEntries {
-		entry := agentflow.TraceEntry{
+		entry := agenticgokit.TraceEntry{
 			Timestamp: je.Timestamp,
 			EventID:   je.EventID,
 			SessionID: je.SessionID,
 			AgentID:   je.AgentID,
-			Hook:      agentflow.HookPoint(je.Hook),
+			Hook:      agenticgokit.HookPoint(je.Hook),
 			Error:     je.Error,
 		}
 
 		// Extract data from direct state (rare in this trace format but handle it)
 		if je.State != nil && je.State.Data != nil {
-			state := agentflow.NewState()
+			state := agenticgokit.NewState()
 			for k, v := range je.State.Data {
 				if v != nil {
 					state.Set(k, v)
@@ -170,7 +170,7 @@ func displayTrace(sessionID, filter string) {
 			// Create new state if needed, or use existing
 			state := entry.State
 			if state == nil {
-				state = agentflow.NewState()
+				state = agenticgokit.NewState()
 			}
 
 			// Add data from output_state
@@ -196,12 +196,12 @@ func displayTrace(sessionID, filter string) {
 
 		// Convert AgentResult if present
 		if je.AgentResult != nil {
-			agentResult := &agentflow.AgentResult{
+			agentResult := &agenticgokit.AgentResult{
 				Error: je.AgentResult.Error,
 			}
 
 			if je.AgentResult.OutputState != nil {
-				outputState := agentflow.NewState()
+				outputState := agenticgokit.NewState()
 				for k, v := range je.AgentResult.OutputState.Data {
 					outputState.Set(k, v)
 				}
@@ -218,7 +218,7 @@ func displayTrace(sessionID, filter string) {
 	}
 
 	// Apply filters
-	var filteredEntries []agentflow.TraceEntry
+	var filteredEntries []agenticgokit.TraceEntry
 	filterAgentName := ""
 	if strings.HasPrefix(filter, "agent=") {
 		filterAgentName = strings.TrimPrefix(filter, "agent=")
@@ -288,7 +288,7 @@ func displayTrace(sessionID, filter string) {
 // Add these new helper functions for table display
 
 // printFormattedTable prints a visually appealing boxed table with proper truncation
-func printFormattedTable(entries []agentflow.TraceEntry) {
+func printFormattedTable(entries []agenticgokit.TraceEntry) {
 	// Define column widths for balanced display
 	const (
 		timeWidth  = 19 // Fixed width for timestamp (15:04:05.000)
@@ -366,7 +366,7 @@ func truncateString(s string, width int) string {
 }
 
 // printVerboseTable displays full details with potential line wrapping
-func printVerboseTable(entries []agentflow.TraceEntry) {
+func printVerboseTable(entries []agenticgokit.TraceEntry) {
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, "TIMESTAMP\tHOOK\tAGENT\tSTATE\tERROR")
 	fmt.Fprintln(w, "---------\t----\t-----\t-----\t-----")
@@ -394,7 +394,7 @@ func printVerboseTable(entries []agentflow.TraceEntry) {
 }
 
 // verboseStateSummary provides a complete state dump for verbose mode
-func verboseStateSummary(s agentflow.State) string {
+func verboseStateSummary(s agenticgokit.State) string {
 	if s == nil {
 		return "-"
 	}
@@ -432,7 +432,7 @@ func safeErrorMsgCLI(errMsg *string) string {
 }
 
 // stateSummary provides a brief summary of state for table view
-func stateSummary(s agentflow.State) string {
+func stateSummary(s agenticgokit.State) string {
 	if s == nil {
 		return "-" // Return dash for nil state
 	}

--- a/cmd/agentcli/main.go
+++ b/cmd/agentcli/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/kunalkushwaha/agentflow/cmd/agentcli/cmd"
+import "github.com/kunalkushwaha/AgenticGoKit/cmd/agentcli/cmd"
 
 func main() {
 	cmd.Execute()

--- a/core/llm_adapters.go
+++ b/core/llm_adapters.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/internal/llm"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/llm"
 )
 
 // AzureOpenAIAdapterOptions holds configuration for Azure OpenAI adapter

--- a/docs/guides/Providers.md
+++ b/docs/guides/Providers.md
@@ -56,9 +56,9 @@ export AZURE_OPENAI_DEPLOYMENT="gpt-4"
 
 **Programmatic configuration:**
 ```go
-import agentflow "github.com/kunalkushwaha/agentflow/core"
+import agenticgokit "github.com/kunalkushwaha/AgenticGoKit/core"
 
-config := agentflow.AzureConfig{
+config := agenticgokit.AzureConfig{
     APIKey:     "your-api-key",
     Endpoint:   "https://your-resource.openai.azure.com",
     Deployment: "gpt-4",

--- a/docs/guides/ToolIntegration.md
+++ b/docs/guides/ToolIntegration.md
@@ -65,7 +65,7 @@ package main
 import (
     "context"
     "fmt"
-    agentflow "github.com/kunalkushwaha/agentflow/core"
+    agenticgokit "github.com/kunalkushwaha/AgenticGoKit/core"
 )
 
 type ToolEnabledAgent struct {

--- a/docs/guides/troubleshooting.md
+++ b/docs/guides/troubleshooting.md
@@ -947,8 +947,8 @@ func main() {
 
 ### Community Resources
 
-- **[GitHub Issues](https://github.com/kunalkushwaha/agentflow/issues)** - Bug reports and feature requests
-- **[GitHub Discussions](https://github.com/kunalkushwaha/agentflow/discussions)** - Questions and community help
+- **[GitHub Issues](https://github.com/kunalkushwaha/AgenticGoKit/issues)** - Bug reports and feature requests
+- **[GitHub Discussions](https://github.com/kunalkushwaha/AgenticGoKit/discussions)** - Questions and community help
 - **[Discord Community](https://discord.gg/agenticgokit)** - Real-time chat and support
 
 ### Issue Template

--- a/docs/tutorials/core-concepts/README.md
+++ b/docs/tutorials/core-concepts/README.md
@@ -130,7 +130,7 @@ import (
     "fmt"
     "log"
     
-    "github.com/kunalkushwaha/agentflow/core"
+    "github.com/kunalkushwaha/AgenticGoKit/core"
 )
 
 // Simple agent implementation

--- a/examples/04-rag-knowledge-base/go.mod
+++ b/examples/04-rag-knowledge-base/go.mod
@@ -1,10 +1,10 @@
-module github.com/kunalkushwaha/agentflow/examples/04-rag-knowledge-base
+module github.com/kunalkushwaha/AgenticGoKit/examples/04-rag-knowledge-base
 
 go 1.21
 
 require (
-	github.com/kunalkushwaha/agentflow v0.1.0
+	github.com/kunalkushwaha/AgenticGoKit v0.3.0-preview
 	github.com/lib/pq v1.10.9
 )
 
-replace github.com/kunalkushwaha/agentflow => ../../
+replace github.com/kunalkushwaha/AgenticGoKit => ../../

--- a/examples/04-rag-knowledge-base/main.go
+++ b/examples/04-rag-knowledge-base/main.go
@@ -10,9 +10,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/core"
-	"github.com/kunalkushwaha/agentflow/examples/04-rag-knowledge-base/agents"
-	"github.com/kunalkushwaha/agentflow/examples/04-rag-knowledge-base/services"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
+	"github.com/kunalkushwaha/AgenticGoKit/examples/04-rag-knowledge-base/agents"
+	"github.com/kunalkushwaha/AgenticGoKit/examples/04-rag-knowledge-base/services"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kunalkushwaha/agentflow
+module github.com/kunalkushwaha/AgenticGoKit
 
 go 1.24.1
 
@@ -8,7 +8,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.5
 	github.com/kunalkushwaha/mcp-navigator-go v0.0.1
-	github.com/lib/pq v1.10.9
 	github.com/pgvector/pgvector-go v0.3.0
 	github.com/prometheus/client_golang v1.22.0
 	github.com/rs/zerolog v1.34.0

--- a/integration/benchmarks/azure_llm_benchmark_test.go
+++ b/integration/benchmarks/azure_llm_benchmark_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/internal/llm" // Keep importing the package under test
+	"github.com/kunalkushwaha/AgenticGoKit/internal/llm" // Keep importing the package under test
 )
 
 // Helper to get Azure Adapter for benchmarks, skipping if not configured

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	agentflow "github.com/kunalkushwaha/agentflow/core"
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/core"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/agents/agents_test_helpers.go
+++ b/internal/agents/agents_test_helpers.go
@@ -7,7 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core"
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core"
 )
 
 // --- Common Test Helper Agents ---
@@ -30,7 +30,7 @@ func (s *SpyAgent) Name() string {
 	return s.name // FIX: Return lowercase 'name' field
 }
 
-func (s *SpyAgent) Run(ctx context.Context, inputState agentflow.State) (agentflow.State, error) {
+func (s *SpyAgent) Run(ctx context.Context, inputState agenticgokit.State) (agenticgokit.State, error) {
 	s.InputData = make(map[string]interface{})
 	for _, key := range inputState.Keys() {
 		if val, ok := inputState.Get(key); ok {
@@ -75,8 +75,8 @@ func (a *DelayAgent) Name() string {
 	return a.name // FIX: Return lowercase 'name' field
 }
 
-// Run implements the agentflow.Agent interface for DelayAgent.
-func (a *DelayAgent) Run(ctx context.Context, input agentflow.State) (agentflow.State, error) {
+// Run implements the agenticgokit.Agent interface for DelayAgent.
+func (a *DelayAgent) Run(ctx context.Context, input agenticgokit.State) (agenticgokit.State, error) {
 	a.RunCount.Add(1)
 	select {
 	case <-time.After(a.Delay):
@@ -107,7 +107,7 @@ func (c *CounterAgent) Name() string {
 	return "CounterAgent" // Or make it configurable if needed
 }
 
-func (c *CounterAgent) Run(ctx context.Context, inputState agentflow.State) (agentflow.State, error) {
+func (c *CounterAgent) Run(ctx context.Context, inputState agenticgokit.State) (agenticgokit.State, error) {
 	outputState := inputState.Clone()
 	countVal, _ := outputState.Get("count")
 	count, _ := countVal.(int) // Assume int, default 0 if not present or wrong type
@@ -135,8 +135,8 @@ func (a *NoOpAgent) Name() string {
 	return "NoOpAgent"
 }
 
-// Run implements the agentflow.Agent interface for NoOpAgent.
-func (a *NoOpAgent) Run(ctx context.Context, input agentflow.State) (agentflow.State, error) {
+// Run implements the agenticgokit.Agent interface for NoOpAgent.
+func (a *NoOpAgent) Run(ctx context.Context, input agenticgokit.State) (agenticgokit.State, error) {
 	return input, nil // Return input state immediately
 }
 
@@ -151,7 +151,7 @@ func (a *SimpleUpdateAgent) Name() string {
 	return fmt.Sprintf("SimpleUpdateAgent(%s)", a.Key) // More descriptive name
 }
 
-func (a *SimpleUpdateAgent) Run(ctx context.Context, inputState agentflow.State) (agentflow.State, error) {
+func (a *SimpleUpdateAgent) Run(ctx context.Context, inputState agenticgokit.State) (agenticgokit.State, error) {
 	outputState := inputState.Clone()
 	countVal, _ := outputState.Get(a.Key)
 	count, _ := countVal.(int)
@@ -163,7 +163,7 @@ func (a *SimpleUpdateAgent) Run(ctx context.Context, inputState agentflow.State)
 // MockAgent for testing purposes
 type MockAgent struct {
 	NameVal      string
-	RunFunc      func(ctx context.Context, inputState agentflow.State) (agentflow.State, error) // Adjusted signature
+	RunFunc      func(ctx context.Context, inputState agenticgokit.State) (agenticgokit.State, error) // Adjusted signature
 	RunCallCount int
 	mu           sync.Mutex
 }
@@ -176,7 +176,7 @@ func (m *MockAgent) Name() string {
 	return m.NameVal
 }
 
-func (m *MockAgent) Run(ctx context.Context, inputState agentflow.State) (agentflow.State, error) {
+func (m *MockAgent) Run(ctx context.Context, inputState agenticgokit.State) (agenticgokit.State, error) {
 	m.mu.Lock()
 	m.RunCallCount++
 	m.mu.Unlock()
@@ -200,9 +200,9 @@ func (m *MockAgent) GetRunCallCount() int {
 }
 
 // Helper to create a simple state for testing
-// Use agentflow.State and agentflow.NewState
-func createState(data map[string]any, meta map[string]string) agentflow.State {
-	s := agentflow.NewState()
+// Use agenticgokit.State and agenticgokit.NewState
+func createState(data map[string]any, meta map[string]string) agenticgokit.State {
+	s := agenticgokit.NewState()
 	if data != nil {
 		for k, v := range data {
 			s.Set(k, v)

--- a/internal/agents/loop_test.go
+++ b/internal/agents/loop_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core"
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core"
 )
 
 // --- Test Helper Agents ---

--- a/internal/agents/parallel_test.go
+++ b/internal/agents/parallel_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core"
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core"
 )
 
 // --- Test Helper Agents ---

--- a/internal/agents/sequential.go
+++ b/internal/agents/sequential.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"fmt"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core"
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core"
 )
 
 // SequentialAgent runs a series of sub-agents one after another.
 type SequentialAgent struct {
 	name   string
-	agents []agentflow.Agent
+	agents []agenticgokit.Agent
 }
 
 // Name returns the name of the sequential agent.
@@ -20,11 +20,11 @@ func (a *SequentialAgent) Name() string {
 
 // NewSequentialAgent creates a new SequentialAgent.
 // It filters out any nil agents provided in the list.
-func NewSequentialAgent(name string, agents ...agentflow.Agent) *SequentialAgent {
-	validAgents := make([]agentflow.Agent, 0, len(agents))
+func NewSequentialAgent(name string, agents ...agenticgokit.Agent) *SequentialAgent {
+	validAgents := make([]agenticgokit.Agent, 0, len(agents))
 	for i, agent := range agents {
 		if agent == nil {
-			agentflow.Logger().Warn().
+			agenticgokit.Logger().Warn().
 				Str("sequential_agent", name).
 				Int("index", i).
 				Msg("SequentialAgent: received a nil agent, skipping.")
@@ -41,9 +41,9 @@ func NewSequentialAgent(name string, agents ...agentflow.Agent) *SequentialAgent
 // Run executes the sequence of sub-agents.
 // It iterates through the configured agents, passing state sequentially.
 // Execution halts immediately if a sub-agent returns an error or if the context is cancelled.
-func (s *SequentialAgent) Run(ctx context.Context, initialState agentflow.State) (agentflow.State, error) {
+func (s *SequentialAgent) Run(ctx context.Context, initialState agenticgokit.State) (agenticgokit.State, error) {
 	if len(s.agents) == 0 {
-		agentflow.Logger().Warn().
+		agenticgokit.Logger().Warn().
 			Str("sequential_agent", s.name).
 			Msg("SequentialAgent: No sub-agents to run.")
 		return initialState, nil // Return input state if no agents
@@ -56,7 +56,7 @@ func (s *SequentialAgent) Run(ctx context.Context, initialState agentflow.State)
 		// Check for context cancellation before running each sub-agent
 		select {
 		case <-ctx.Done():
-			agentflow.Logger().Warn().
+			agenticgokit.Logger().Warn().
 				Str("sequential_agent", s.name).
 				Int("agent_index", i).
 				Msg("SequentialAgent: Context cancelled before running agent.")
@@ -74,7 +74,7 @@ func (s *SequentialAgent) Run(ctx context.Context, initialState agentflow.State)
 		outputState, agentErr := agent.Run(ctx, inputState)
 		if agentErr != nil {
 			err = fmt.Errorf("SequentialAgent '%s': error in sub-agent %d: %w", s.name, i, agentErr)
-			agentflow.Logger().Error().
+			agenticgokit.Logger().Error().
 				Str("sequential_agent", s.name).
 				Int("agent_index", i).
 				Err(agentErr).

--- a/internal/agents/sequential_test.go
+++ b/internal/agents/sequential_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core"
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core"
 )
 
 // --- Test Helper Agents ---

--- a/internal/factory/agent_factory.go
+++ b/internal/factory/agent_factory.go
@@ -6,10 +6,10 @@ import (
 	"log"
 	"os"
 
-	"github.com/kunalkushwaha/agentflow/core"
-	"github.com/kunalkushwaha/agentflow/internal/llm"
-	"github.com/kunalkushwaha/agentflow/internal/mcp" // Import the MCP package
-	"github.com/kunalkushwaha/agentflow/internal/tools"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/llm"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/mcp" // Import the MCP package
+	"github.com/kunalkushwaha/AgenticGoKit/internal/tools"
 )
 
 // RunnerConfig allows customization but provides sensible defaults.

--- a/internal/llm/ollama_adapter_test.go
+++ b/internal/llm/ollama_adapter_test.go
@@ -52,7 +52,8 @@ func TestOllamaAdapter_Call(t *testing.T) {
 			defer server.Close()
 
 			adapter := &OllamaAdapter{
-				model:       "gemma3:latest",
+				baseURL:     server.URL,
+				model:       "llama3.2:latest",
 				maxTokens:   100,
 				temperature: 0.7,
 			}
@@ -72,4 +73,89 @@ func TestOllamaAdapter_Call(t *testing.T) {
 			}
 		})
 	}
+}
+func TestOllamaAdapter_Embeddings(t *testing.T) {
+	tests := []struct {
+		name           string
+		responseBody   string
+		responseStatus int
+		texts          []string
+		expectedLength int
+		expectedError  string
+	}{
+		{
+			name:           "Valid text returns embedding",
+			responseBody:   `{"embedding": [0.1, 0.2, 0.3, 0.4, 0.5]}`,
+			responseStatus: http.StatusOK,
+			texts:          []string{"Hello world"},
+			expectedLength: 5, // Length of the embedding vector
+			expectedError:  "",
+		},
+		{
+			name:           "Empty texts returns empty result",
+			responseBody:   "",
+			responseStatus: http.StatusOK,
+			texts:          []string{},
+			expectedLength: 0,
+			expectedError:  "",
+		},
+		{
+			name:           "API error returns error",
+			responseBody:   `{"error": "Model not found"}`,
+			responseStatus: http.StatusNotFound,
+			texts:          []string{"Hello world"},
+			expectedLength: 0,
+			expectedError:  "Ollama embeddings API error for text 0: {\"error\": \"Model not found\"}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tt.responseStatus)
+				w.Write([]byte(tt.responseBody))
+			}))
+			defer server.Close()
+
+			adapter := &OllamaAdapter{
+				baseURL:        server.URL,
+				model:          "llama3.2:latest",
+				embeddingModel: "nomic-embed-text:latest",
+				maxTokens:      100,
+				temperature:    0.7,
+			}
+
+			result, err := adapter.Embeddings(context.Background(), tt.texts)
+
+			if tt.expectedError != "" {
+				assert.EqualError(t, err, tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			if tt.expectedLength == 0 && len(tt.texts) == 0 {
+				assert.Equal(t, [][]float64{}, result)
+			} else if tt.expectedLength > 0 {
+				assert.Len(t, result, len(tt.texts))
+				if len(result) > 0 {
+					assert.Len(t, result[0], tt.expectedLength)
+				}
+			}
+		})
+	}
+}
+
+func TestOllamaAdapter_SetEmbeddingModel(t *testing.T) {
+	adapter := &OllamaAdapter{
+		embeddingModel: "nomic-embed-text:latest",
+	}
+
+	// Test setting a new model
+	adapter.SetEmbeddingModel("all-minilm:latest")
+	assert.Equal(t, "all-minilm:latest", adapter.embeddingModel)
+
+	// Test that empty string doesn't change the model
+	adapter.SetEmbeddingModel("")
+	assert.Equal(t, "all-minilm:latest", adapter.embeddingModel)
 }

--- a/internal/mcp/cache.go
+++ b/internal/mcp/cache.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/core"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
 )
 
 // MemoryCache implements MCPCache using in-memory storage with LRU eviction.

--- a/internal/mcp/cache_manager.go
+++ b/internal/mcp/cache_manager.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/core"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
 )
 
 // CacheManager implements MCPCacheManager and manages cache instances for MCP tools.

--- a/internal/mcp/factory.go
+++ b/internal/mcp/factory.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/core"
-	"github.com/kunalkushwaha/agentflow/internal/tools"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/tools"
 )
 
 // NewMCPManager creates a new MCP manager with the given configuration.

--- a/internal/mcp/manager.go
+++ b/internal/mcp/manager.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/core"
-	"github.com/kunalkushwaha/agentflow/internal/tools"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/tools"
 	"github.com/kunalkushwaha/mcp-navigator-go/pkg/client"
 	"github.com/kunalkushwaha/mcp-navigator-go/pkg/discovery"
 	"github.com/kunalkushwaha/mcp-navigator-go/pkg/mcp"

--- a/internal/mcp/retry_policies.go
+++ b/internal/mcp/retry_policies.go
@@ -8,7 +8,7 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/core"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
 	"github.com/rs/zerolog"
 )
 

--- a/internal/mcp/tool.go
+++ b/internal/mcp/tool.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/core"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
 	"github.com/kunalkushwaha/mcp-navigator-go/pkg/client"
 	"github.com/kunalkushwaha/mcp-navigator-go/pkg/mcp"
 )

--- a/internal/memory/fallback_memory.go
+++ b/internal/memory/fallback_memory.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core" // Import core types
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core" // Import core types
 )
 
 // FallbackVectorMemory implements the agentflow.VectorMemory interface by attempting

--- a/internal/memory/pgvector_memory.go
+++ b/internal/memory/pgvector_memory.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"strings"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core" // Import core types
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core" // Import core types
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pgvector/pgvector-go"

--- a/internal/memory/weaviate_memory.go
+++ b/internal/memory/weaviate_memory.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"strings"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core" // Import core types
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core" // Import core types
 
 	"github.com/weaviate/weaviate-go-client/v4/weaviate"
 	"github.com/weaviate/weaviate-go-client/v4/weaviate/auth"

--- a/internal/orchestrator/collaborate.go
+++ b/internal/orchestrator/collaborate.go
@@ -6,24 +6,24 @@ import (
 	"fmt"
 	"sync"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core"
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core"
 )
 
 // CollaborativeOrchestrator dispatches events to all registered handlers concurrently.
 type CollaborativeOrchestrator struct {
-	handlers map[string]agentflow.AgentHandler // Use AgentHandler interface and map by name
+	handlers map[string]agenticgokit.AgentHandler // Use AgentHandler interface and map by name
 	mu       sync.RWMutex
 }
 
 // NewCollaborativeOrchestrator creates a new CollaborativeOrchestrator.
 func NewCollaborativeOrchestrator() *CollaborativeOrchestrator {
 	return &CollaborativeOrchestrator{
-		handlers: make(map[string]agentflow.AgentHandler), // Initialize map
+		handlers: make(map[string]agenticgokit.AgentHandler), // Initialize map
 	}
 }
 
 // RegisterAgent adds an agent handler to the orchestrator.
-func (o *CollaborativeOrchestrator) RegisterAgent(name string, handler agentflow.AgentHandler) error {
+func (o *CollaborativeOrchestrator) RegisterAgent(name string, handler agenticgokit.AgentHandler) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
@@ -33,47 +33,47 @@ func (o *CollaborativeOrchestrator) RegisterAgent(name string, handler agentflow
 	}
 	// Store handler by name
 	o.handlers[name] = handler
-	agentflow.Logger().Info().
+	agenticgokit.Logger().Info().
 		Str("agent", name).
 		Msg("CollaborativeOrchestrator: Registered agent")
 	return nil
 }
 
 // Dispatch sends the event to all registered handlers concurrently.
-func (o *CollaborativeOrchestrator) Dispatch(ctx context.Context, event agentflow.Event) (agentflow.AgentResult, error) {
+func (o *CollaborativeOrchestrator) Dispatch(ctx context.Context, event agenticgokit.Event) (agenticgokit.AgentResult, error) {
 	if event == nil {
-		agentflow.Logger().Warn().Msg("CollaborativeOrchestrator: Received nil event, skipping dispatch.")
+		agenticgokit.Logger().Warn().Msg("CollaborativeOrchestrator: Received nil event, skipping dispatch.")
 		err := errors.New("cannot dispatch nil event")
-		return agentflow.AgentResult{Error: err.Error()}, err
+		return agenticgokit.AgentResult{Error: err.Error()}, err
 	}
 
 	o.mu.RLock()
 	// Create a slice of handlers to run from the map values
-	handlersToRun := make([]agentflow.AgentHandler, 0, len(o.handlers))
+	handlersToRun := make([]agenticgokit.AgentHandler, 0, len(o.handlers))
 	for _, handler := range o.handlers {
 		handlersToRun = append(handlersToRun, handler)
 	}
 	o.mu.RUnlock()
 
 	if len(handlersToRun) == 0 {
-		agentflow.Logger().Warn().
+		agenticgokit.Logger().Warn().
 			Str("event_id", event.GetID()).
 			Msg("CollaborativeOrchestrator: No handlers registered, skipping dispatch")
-		return agentflow.AgentResult{}, nil
+		return agenticgokit.AgentResult{}, nil
 	}
 
 	var wg sync.WaitGroup
 	errsChan := make(chan error, len(handlersToRun))
-	resultsChan := make(chan agentflow.AgentResult, len(handlersToRun))
+	resultsChan := make(chan agenticgokit.AgentResult, len(handlersToRun))
 
 	wg.Add(len(handlersToRun))
-	agentflow.Logger().Info().
+	agenticgokit.Logger().Info().
 		Str("event_id", event.GetID()).
 		Int("handler_count", len(handlersToRun)).
 		Msg("CollaborativeOrchestrator: Dispatching event to handlers")
 
 	// Create initial state from event
-	initialState := agentflow.NewState()
+	initialState := agenticgokit.NewState()
 	if eventData := event.GetData(); eventData != nil {
 		for k, v := range eventData {
 			initialState.Set(k, v)
@@ -87,11 +87,11 @@ func (o *CollaborativeOrchestrator) Dispatch(ctx context.Context, event agentflo
 	}
 
 	for _, handler := range handlersToRun {
-		go func(h agentflow.AgentHandler) {
+		go func(h agenticgokit.AgentHandler) {
 			defer wg.Done()
 			if h == nil {
 				err := fmt.Errorf("encountered nil handler during dispatch for event ID %s", event.GetID())
-				agentflow.Logger().Error().
+				agenticgokit.Logger().Error().
 					Str("event_id", event.GetID()).
 					Msg(err.Error())
 				errsChan <- err
@@ -102,13 +102,13 @@ func (o *CollaborativeOrchestrator) Dispatch(ctx context.Context, event agentflo
 			result, err := h.Run(ctx, event, stateForHandler)
 
 			if err != nil {
-				agentflow.Logger().Error().
+				agenticgokit.Logger().Error().
 					Str("event_id", event.GetID()).
 					Err(err).
 					Msg("CollaborativeOrchestrator: Handler error")
 				errsChan <- err
 			} else {
-				agentflow.Logger().Info().
+				agenticgokit.Logger().Info().
 					Str("event_id", event.GetID()).
 					Msg("CollaborativeOrchestrator: Handler finished successfully")
 				resultsChan <- result
@@ -126,9 +126,9 @@ func (o *CollaborativeOrchestrator) Dispatch(ctx context.Context, event agentflo
 		collectedErrors = append(collectedErrors, err)
 	}
 
-	finalState := agentflow.NewState()
-	if sessionID, ok := initialState.GetMeta(agentflow.SessionIDKey); ok {
-		finalState.SetMeta(agentflow.SessionIDKey, sessionID)
+	finalState := agenticgokit.NewState()
+	if sessionID, ok := initialState.GetMeta(agenticgokit.SessionIDKey); ok {
+		finalState.SetMeta(agenticgokit.SessionIDKey, sessionID)
 	}
 	for _, key := range initialState.Keys() {
 		if val, ok := initialState.Get(key); ok {
@@ -144,7 +144,7 @@ func (o *CollaborativeOrchestrator) Dispatch(ctx context.Context, event agentflo
 				}
 			}
 			for _, key := range result.OutputState.MetaKeys() {
-				if key != agentflow.SessionIDKey && key != agentflow.RouteMetadataKey {
+				if key != agenticgokit.SessionIDKey && key != agenticgokit.RouteMetadataKey {
 					if val, ok := result.OutputState.GetMeta(key); ok {
 						finalState.SetMeta(key, val)
 					}
@@ -154,34 +154,34 @@ func (o *CollaborativeOrchestrator) Dispatch(ctx context.Context, event agentflo
 	}
 
 	if len(collectedErrors) > 0 {
-		agentflow.Logger().Warn().
+		agenticgokit.Logger().Warn().
 			Str("event_id", event.GetID()).
 			Int("error_count", len(collectedErrors)).
 			Msg("CollaborativeOrchestrator: Finished dispatch with errors")
 		aggErr := errors.Join(collectedErrors...)
-		return agentflow.AgentResult{OutputState: finalState, Error: aggErr.Error()}, aggErr
+		return agenticgokit.AgentResult{OutputState: finalState, Error: aggErr.Error()}, aggErr
 	}
 
-	agentflow.Logger().Info().
+	agenticgokit.Logger().Info().
 		Str("event_id", event.GetID()).
 		Msg("CollaborativeOrchestrator: Finished dispatch successfully")
-	return agentflow.AgentResult{OutputState: finalState}, nil
+	return agenticgokit.AgentResult{OutputState: finalState}, nil
 }
 
 // DispatchAll needs the same signature update and logic adjustment
-func (o *CollaborativeOrchestrator) DispatchAll(ctx context.Context, event agentflow.Event) (agentflow.AgentResult, error) {
+func (o *CollaborativeOrchestrator) DispatchAll(ctx context.Context, event agenticgokit.Event) (agenticgokit.AgentResult, error) {
 	return o.Dispatch(ctx, event)
 }
 
 // Stop is a placeholder for potential cleanup tasks.
 func (o *CollaborativeOrchestrator) Stop() {
-	agentflow.Logger().Info().Msg("CollaborativeOrchestrator stopping...")
+	agenticgokit.Logger().Info().Msg("CollaborativeOrchestrator stopping...")
 }
 
 // GetCallbackRegistry returns nil as CollaborativeOrchestrator doesn't manage callbacks directly.
-func (o *CollaborativeOrchestrator) GetCallbackRegistry() *agentflow.CallbackRegistry {
+func (o *CollaborativeOrchestrator) GetCallbackRegistry() *agenticgokit.CallbackRegistry {
 	return nil
 }
 
 // Compile-time check to ensure CollaborativeOrchestrator implements Orchestrator
-var _ agentflow.Orchestrator = (*CollaborativeOrchestrator)(nil)
+var _ agenticgokit.Orchestrator = (*CollaborativeOrchestrator)(nil)

--- a/internal/orchestrator/collaborate_test.go
+++ b/internal/orchestrator/collaborate_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core"
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/orchestrator/orchestrator_test_helpers.go
+++ b/internal/orchestrator/orchestrator_test_helpers.go
@@ -6,22 +6,22 @@ import (
 	"sync"
 	"time"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core"
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core"
 )
 
 // MockOrchestrator for testing handler interactions
 type MockOrchestrator struct {
-	eventHandlers map[string]agentflow.EventHandler // Renamed for clarity
-	agentHandlers map[string]agentflow.AgentHandler // Added for AgentHandler registration
-	registry      *agentflow.CallbackRegistry       // Add registry if needed
+	eventHandlers map[string]agenticgokit.EventHandler // Renamed for clarity
+	agentHandlers map[string]agenticgokit.AgentHandler // Added for AgentHandler registration
+	registry      *agenticgokit.CallbackRegistry       // Add registry if needed
 	mu            sync.Mutex
 }
 
 // NewMockOrchestrator creates a mock orchestrator
-func NewMockOrchestrator(registry *agentflow.CallbackRegistry) *MockOrchestrator {
+func NewMockOrchestrator(registry *agenticgokit.CallbackRegistry) *MockOrchestrator {
 	return &MockOrchestrator{
-		eventHandlers: make(map[string]agentflow.EventHandler), // Initialize map
-		agentHandlers: make(map[string]agentflow.AgentHandler), // Initialize map
+		eventHandlers: make(map[string]agenticgokit.EventHandler), // Initialize map
+		agentHandlers: make(map[string]agenticgokit.AgentHandler), // Initialize map
 		registry:      registry,
 	}
 }
@@ -32,12 +32,12 @@ func (m *MockOrchestrator) RegisterAgent(agentID string, handler interface{}) er
 	defer m.mu.Unlock()
 
 	// Check if it's an AgentHandler
-	if ah, ok := handler.(agentflow.AgentHandler); ok {
+	if ah, ok := handler.(agenticgokit.AgentHandler); ok {
 		m.agentHandlers[agentID] = ah
 		return nil
 	}
 	// Check if it's an EventHandler
-	if eh, ok := handler.(agentflow.EventHandler); ok {
+	if eh, ok := handler.(agenticgokit.EventHandler); ok {
 		m.eventHandlers[agentID] = eh
 		return nil
 	}
@@ -46,7 +46,7 @@ func (m *MockOrchestrator) RegisterAgent(agentID string, handler interface{}) er
 }
 
 // Dispatch simulates routing based on TargetAgentID (like RouteOrchestrator)
-func (m *MockOrchestrator) Dispatch(event agentflow.Event) error {
+func (m *MockOrchestrator) Dispatch(event agenticgokit.Event) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if event == nil {
@@ -70,7 +70,7 @@ func (m *MockOrchestrator) Dispatch(event agentflow.Event) error {
 		// FIX: Call Run with correct signature and handle return values
 		// Pass background context and new empty state for the mock call
 		ctx := context.Background()
-		state := agentflow.NewState()
+		state := agenticgokit.NewState()
 		_, err := handler.Run(ctx, event, state) // Call Run, ignore result for mock Dispatch
 		return err                               // Return only the error, matching mock Dispatch signature
 	}
@@ -87,7 +87,7 @@ func (m *MockOrchestrator) Dispatch(event agentflow.Event) error {
 func (m *MockOrchestrator) Stop() {}
 
 // GetCallbackRegistry returns the stored registry
-func (m *MockOrchestrator) GetCallbackRegistry() *agentflow.CallbackRegistry {
+func (m *MockOrchestrator) GetCallbackRegistry() *agenticgokit.CallbackRegistry {
 	return m.registry
 }
 
@@ -95,7 +95,7 @@ func (m *MockOrchestrator) GetCallbackRegistry() *agentflow.CallbackRegistry {
 type SpyEventHandler struct {
 	AgentName    string
 	HandleCalled bool
-	LastEvent    agentflow.Event
+	LastEvent    agenticgokit.Event
 	ReturnError  error
 	mu           sync.Mutex
 	eventCount   int
@@ -103,8 +103,8 @@ type SpyEventHandler struct {
 	failOn       string
 }
 
-// Handle implements the agentflow.EventHandler interface.
-func (h *SpyEventHandler) Handle(event agentflow.Event) error { // Correct signature for EventHandler
+// Handle implements the agenticgokit.EventHandler interface.
+func (h *SpyEventHandler) Handle(event agenticgokit.Event) error { // Correct signature for EventHandler
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -149,7 +149,7 @@ type SlowSpyEventHandler struct {
 	delay           time.Duration
 }
 
-func (s *SlowSpyEventHandler) Handle(e agentflow.Event) error {
+func (s *SlowSpyEventHandler) Handle(e agenticgokit.Event) error {
 	time.Sleep(s.delay)
 	return s.SpyEventHandler.Handle(e) // Call embedded Handle
 }
@@ -158,12 +158,12 @@ func (s *SlowSpyEventHandler) Handle(e agentflow.Event) error {
 type SpyAgentHandler struct {
 	AgentName    string
 	RunCalled    bool // Renamed from HandleCalled
-	LastEvent    agentflow.Event
-	LastRegistry *agentflow.CallbackRegistry
-	LastState    agentflow.State // Store the received state
+	LastEvent    agenticgokit.Event
+	LastRegistry *agenticgokit.CallbackRegistry
+	LastState    agenticgokit.State // Store the received state
 	LastContext  context.Context // Store the received context
 	ReturnError  error
-	ReturnResult agentflow.AgentResult // Define what result to return
+	ReturnResult agenticgokit.AgentResult // Define what result to return
 	mu           sync.Mutex
 	eventCount   int
 	events       []string // Store event IDs
@@ -171,8 +171,8 @@ type SpyAgentHandler struct {
 }
 
 // FIX: Implement the Run method required by the AgentHandler interface.
-// Run implements the agentflow.AgentHandler interface.
-func (h *SpyAgentHandler) Run(ctx context.Context, event agentflow.Event, state agentflow.State) (agentflow.AgentResult, error) {
+// Run implements the agenticgokit.AgentHandler interface.
+func (h *SpyAgentHandler) Run(ctx context.Context, event agenticgokit.Event, state agenticgokit.State) (agenticgokit.AgentResult, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -191,7 +191,7 @@ func (h *SpyAgentHandler) Run(ctx context.Context, event agentflow.Event, state 
 				err = fmt.Errorf("handler '%s' failed deliberately for event '%s'", h.AgentName, eventID)
 			}
 			// Return default/empty result along with the error
-			return agentflow.AgentResult{}, err
+			return agenticgokit.AgentResult{}, err
 		}
 	}
 	// Return the configured result and error

--- a/internal/orchestrator/route.go
+++ b/internal/orchestrator/route.go
@@ -6,77 +6,77 @@ import (
 	"fmt"
 	"sync"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core"
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core"
 )
 
 // RouteMetadataKey is the key used in event metadata to specify a target handler name.
-const RouteMetadataKey = agentflow.RouteMetadataKey // Use the agentflow constant
+const RouteMetadataKey = agenticgokit.RouteMetadataKey // Use the agenticgokit constant
 
 // RouteOrchestrator routes events to a single registered handler based on metadata.
 type RouteOrchestrator struct {
-	handlers map[string]agentflow.AgentHandler
-	registry *agentflow.CallbackRegistry
+	handlers map[string]agenticgokit.AgentHandler
+	registry *agenticgokit.CallbackRegistry
 	emitter  EventEmitter // Interface for emitting events
 	mu       sync.RWMutex
 }
 
 // EventEmitter is an interface for components that can emit events
 type EventEmitter interface {
-	Emit(event agentflow.Event) error
+	Emit(event agenticgokit.Event) error
 }
 
 // NewRouteOrchestrator creates a simple routing orchestrator.
 // It requires the CallbackRegistry from the Runner.
-func NewRouteOrchestrator(registry *agentflow.CallbackRegistry) *RouteOrchestrator { // Accept registry
+func NewRouteOrchestrator(registry *agenticgokit.CallbackRegistry) *RouteOrchestrator { // Accept registry
 	if registry == nil {
-		agentflow.Logger().Warn().Msg("NewRouteOrchestrator created with a nil CallbackRegistry")
+		agenticgokit.Logger().Warn().Msg("NewRouteOrchestrator created with a nil CallbackRegistry")
 	}
 	return &RouteOrchestrator{
-		handlers: make(map[string]agentflow.AgentHandler),
+		handlers: make(map[string]agenticgokit.AgentHandler),
 		registry: registry, // Store the registry
 	}
 }
 
 // RegisterAgent adds an agent handler.
-func (o *RouteOrchestrator) RegisterAgent(agentID string, handler agentflow.AgentHandler) error {
+func (o *RouteOrchestrator) RegisterAgent(agentID string, handler agenticgokit.AgentHandler) error {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if handler == nil {
-		agentflow.Logger().Warn().
+		agenticgokit.Logger().Warn().
 			Str("agent_id", agentID).
 			Msg("Attempted to register a nil handler")
 		return fmt.Errorf("cannot register a nil handler for agent ID '%s'", agentID)
 	}
 	if _, exists := o.handlers[agentID]; exists {
-		agentflow.Logger().Warn().
+		agenticgokit.Logger().Warn().
 			Str("agent_id", agentID).
 			Msg("Overwriting handler for agent")
 	}
 	o.handlers[agentID] = handler
-	agentflow.Logger().Debug().
+	agenticgokit.Logger().Debug().
 		Str("agent_id", agentID).
 		Msg("RouteOrchestrator: Registered agent")
 	return nil
 }
 
 // Dispatch routes the event based on the RouteMetadataKey and executes the agent.
-func (o *RouteOrchestrator) Dispatch(ctx context.Context, event agentflow.Event) (agentflow.AgentResult, error) {
+func (o *RouteOrchestrator) Dispatch(ctx context.Context, event agenticgokit.Event) (agenticgokit.AgentResult, error) {
 	if event == nil {
 		err := errors.New("cannot dispatch nil event")
-		return agentflow.AgentResult{Error: err.Error()}, err
+		return agenticgokit.AgentResult{Error: err.Error()}, err
 	}
 
 	o.mu.RLock() // Lock for reading handlers map
 
-	targetName, targetNameOK := event.GetMetadataValue(agentflow.RouteMetadataKey)
+	targetName, targetNameOK := event.GetMetadataValue(agenticgokit.RouteMetadataKey)
 	if !targetNameOK {
 		o.mu.RUnlock()
-		err := fmt.Errorf("missing routing key '%s' in event metadata (event %s)", agentflow.RouteMetadataKey, event.GetID())
-		agentflow.Logger().Error().
+		err := fmt.Errorf("missing routing key '%s' in event metadata (event %s)", agenticgokit.RouteMetadataKey, event.GetID())
+		agenticgokit.Logger().Error().
 			Str("event_id", event.GetID()).
-			Str("route_key", agentflow.RouteMetadataKey).
+			Str("route_key", agenticgokit.RouteMetadataKey).
 			Msgf("RouteOrchestrator: Error - %v", err)
-		return agentflow.AgentResult{Error: err.Error()}, err
+		return agenticgokit.AgentResult{Error: err.Error()}, err
 	}
 
 	handler, exists := o.handlers[targetName]
@@ -84,23 +84,23 @@ func (o *RouteOrchestrator) Dispatch(ctx context.Context, event agentflow.Event)
 
 	if !exists {
 		err := fmt.Errorf("no agent handler registered for target '%s' (event %s)", targetName, event.GetID())
-		agentflow.Logger().Error().
+		agenticgokit.Logger().Error().
 			Str("event_id", event.GetID()).
 			Str("target", targetName).
 			Msgf("RouteOrchestrator: Error - %v", err)
-		return agentflow.AgentResult{Error: err.Error()}, err
+		return agenticgokit.AgentResult{Error: err.Error()}, err
 	}
 
-	var agentResult agentflow.AgentResult
+	var agentResult agenticgokit.AgentResult
 	var agentErr error
-	var currentState agentflow.State = agentflow.NewState()
+	var currentState agenticgokit.State = agenticgokit.NewState()
 
 	// 1. Invoke BeforeAgentRun hooks
 	if o.registry != nil {
-		beforeArgs := agentflow.CallbackArgs{Ctx: ctx, Hook: agentflow.HookBeforeAgentRun, Event: event, State: currentState, AgentID: targetName}
+		beforeArgs := agenticgokit.CallbackArgs{Ctx: ctx, Hook: agenticgokit.HookBeforeAgentRun, Event: event, State: currentState, AgentID: targetName}
 		newState, hookErr := o.registry.Invoke(ctx, beforeArgs)
 		if hookErr != nil {
-			agentflow.Logger().Error().
+			agenticgokit.Logger().Error().
 				Str("agent_id", targetName).
 				Err(hookErr).
 				Msg("RouteOrchestrator: Error in BeforeAgentRun hooks")
@@ -113,7 +113,7 @@ func (o *RouteOrchestrator) Dispatch(ctx context.Context, event agentflow.Event)
 	// Merge event data into the current state
 	eventData := event.GetData()
 	if eventData != nil {
-		agentflow.Logger().Debug().
+		agenticgokit.Logger().Debug().
 			Str("agent_id", targetName).
 			Msg("RouteOrchestrator: Merging event data into state")
 		for key, value := range eventData {
@@ -122,7 +122,7 @@ func (o *RouteOrchestrator) Dispatch(ctx context.Context, event agentflow.Event)
 	}
 
 	// 2. Run the agent handler
-	agentflow.Logger().Debug().
+	agenticgokit.Logger().Debug().
 		Str("agent_id", targetName).
 		Str("event_id", event.GetID()).
 		Interface("state_keys", currentState.Keys()).
@@ -131,14 +131,14 @@ func (o *RouteOrchestrator) Dispatch(ctx context.Context, event agentflow.Event)
 
 	// 3. Invoke AfterAgentRun hooks (always, even on error)
 	if o.registry != nil {
-		var stateForAfterHook agentflow.State = currentState
+		var stateForAfterHook agenticgokit.State = currentState
 		if agentErr == nil && agentResult.OutputState != nil {
 			stateForAfterHook = agentResult.OutputState
 		}
 
-		afterArgs := agentflow.CallbackArgs{
+		afterArgs := agenticgokit.CallbackArgs{
 			Ctx:         ctx,
-			Hook:        agentflow.HookAfterAgentRun,
+			Hook:        agenticgokit.HookAfterAgentRun,
 			Event:       event,
 			State:       stateForAfterHook,
 			AgentID:     targetName,
@@ -146,12 +146,12 @@ func (o *RouteOrchestrator) Dispatch(ctx context.Context, event agentflow.Event)
 			Error:       agentErr,
 		}
 		if agentErr != nil {
-			afterArgs.Hook = agentflow.HookAgentError
+			afterArgs.Hook = agenticgokit.HookAgentError
 		}
 
 		finalStateFromHooks, hookErr := o.registry.Invoke(ctx, afterArgs)
 		if hookErr != nil {
-			agentflow.Logger().Error().
+			agenticgokit.Logger().Error().
 				Str("agent_id", targetName).
 				Str("hook", string(afterArgs.Hook)).
 				Err(hookErr).
@@ -171,24 +171,24 @@ func (o *RouteOrchestrator) Dispatch(ctx context.Context, event agentflow.Event)
 					routeDisplay = currentRoute
 				}
 
-				agentflow.Logger().Debug().
+				agenticgokit.Logger().Debug().
 					Str("from", routeDisplay).
 					Str("to", newRoute).
 					Msg("RouteOrchestrator: Processing route change")
 
 				if o.emitter != nil {
 					if err := o.emitter.Emit(fixedEvent); err != nil {
-						agentflow.Logger().Error().
+						agenticgokit.Logger().Error().
 							Str("to", newRoute).
 							Err(err).
 							Msg("RouteOrchestrator: Failed to emit new event with updated routing")
 					} else {
-						agentflow.Logger().Debug().
+						agenticgokit.Logger().Debug().
 							Str("to", newRoute).
 							Msg("RouteOrchestrator: Successfully queued event with updated routing")
 					}
 				} else {
-					agentflow.Logger().Warn().
+					agenticgokit.Logger().Warn().
 						Str("to", newRoute).
 						Msg("RouteOrchestrator: No emitter available to queue event with updated routing")
 				}
@@ -200,7 +200,7 @@ func (o *RouteOrchestrator) Dispatch(ctx context.Context, event agentflow.Event)
 }
 
 // EnsureProperRouting ensures that agent result state metadata is correctly reflected in event routing
-func (o *RouteOrchestrator) EnsureProperRouting(event agentflow.Event, result agentflow.AgentResult) agentflow.Event {
+func (o *RouteOrchestrator) EnsureProperRouting(event agenticgokit.Event, result agenticgokit.AgentResult) agenticgokit.Event {
 	if result.OutputState == nil {
 		return event
 	}
@@ -213,13 +213,13 @@ func (o *RouteOrchestrator) EnsureProperRouting(event agentflow.Event, result ag
 	currentRoute, hasCurrentRoute := event.GetMetadataValue(RouteMetadataKey)
 	if !hasCurrentRoute {
 		currentRoute = ""
-		agentflow.Logger().Warn().
+		agenticgokit.Logger().Warn().
 			Str("new_route", newRoute).
 			Msg("RouteOrchestrator: No routing metadata in current event, will create new event with route")
 	}
 
 	if currentRoute != newRoute {
-		agentflow.Logger().Debug().
+		agenticgokit.Logger().Debug().
 			Str("from", currentRoute).
 			Str("to", newRoute).
 			Msg("RouteOrchestrator: Detected routing change, creating new event")
@@ -240,7 +240,7 @@ func (o *RouteOrchestrator) EnsureProperRouting(event agentflow.Event, result ag
 
 		newMeta[RouteMetadataKey] = newRoute
 
-		newEvent := agentflow.NewEvent(
+		newEvent := agenticgokit.NewEvent(
 			newRoute,
 			stateData,
 			newMeta,
@@ -255,7 +255,7 @@ func (o *RouteOrchestrator) EnsureProperRouting(event agentflow.Event, result ag
 }
 
 // GetCallbackRegistry returns the associated registry.
-func (o *RouteOrchestrator) GetCallbackRegistry() *agentflow.CallbackRegistry {
+func (o *RouteOrchestrator) GetCallbackRegistry() *agenticgokit.CallbackRegistry {
 	return o.registry
 }
 
@@ -264,33 +264,33 @@ func (o *RouteOrchestrator) SetEmitter(emitter EventEmitter) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	o.emitter = emitter
-	agentflow.Logger().Debug().Msg("RouteOrchestrator: Emitter configured successfully")
+	agenticgokit.Logger().Debug().Msg("RouteOrchestrator: Emitter configured successfully")
 }
 
 // Stop performs cleanup (currently none needed for RouteOrchestrator).
 func (o *RouteOrchestrator) Stop() {
-	agentflow.Logger().Info().Msg("RouteOrchestrator stopping.")
+	agenticgokit.Logger().Info().Msg("RouteOrchestrator stopping.")
 }
 
 // DispatchAll implements the Orchestrator interface but provides more graceful handling
 // for events without routing information.
-func (o *RouteOrchestrator) DispatchAll(ctx context.Context, event agentflow.Event) (agentflow.AgentResult, error) {
-	_, hasRouting := event.GetMetadataValue(agentflow.RouteMetadataKey)
+func (o *RouteOrchestrator) DispatchAll(ctx context.Context, event agenticgokit.Event) (agenticgokit.AgentResult, error) {
+	_, hasRouting := event.GetMetadataValue(agenticgokit.RouteMetadataKey)
 
 	if !hasRouting {
 		if errorData, hasError := event.GetData()["error"]; hasError {
-			agentflow.Logger().Warn().
+			agenticgokit.Logger().Warn().
 				Str("event_id", event.GetID()).
 				Msg("RouteOrchestrator: Processing error event without routing key")
 
-			return agentflow.AgentResult{
-				OutputState: agentflow.NewState(),
+			return agenticgokit.AgentResult{
+				OutputState: agenticgokit.NewState(),
 				Error:       fmt.Sprintf("Error event processed: %v", errorData),
 			}, nil
 		}
 	}
 
-	agentflow.Logger().Debug().
+	agenticgokit.Logger().Debug().
 		Str("event_id", event.GetID()).
 		Msg("RouteOrchestrator: DispatchAll forwarding to Dispatch")
 	return o.Dispatch(ctx, event)

--- a/internal/orchestrator/route_test.go
+++ b/internal/orchestrator/route_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	agentflow "github.com/kunalkushwaha/agentflow/internal/core"
+	agenticgokit "github.com/kunalkushwaha/AgenticGoKit/internal/core"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/scaffold/config.go
+++ b/internal/scaffold/config.go
@@ -1,7 +1,7 @@
 package scaffold
 
-// AgentFlowVersion represents the version of AgentFlow to use in generated projects
-const AgentFlowVersion = "v0.3.0-preview"
+// AgenticGoKitVersion represents the version of AgenticGoKit to use in generated projects
+const AgenticGoKitVersion = "v0.3.2"
 
 // AgentInfo represents information about an agent including its name and purpose
 type AgentInfo struct {
@@ -12,7 +12,7 @@ type AgentInfo struct {
 	Role        string // Agent role like "collaborative", "sequential", "loop"
 }
 
-// ProjectConfig represents the configuration for creating a new AgentFlow project
+// ProjectConfig represents the configuration for creating a new AgenticGoKit project
 type ProjectConfig struct {
 	Name          string
 	NumAgents     int

--- a/internal/scaffold/generators/agent.go
+++ b/internal/scaffold/generators/agent.go
@@ -6,50 +6,13 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/kunalkushwaha/agentflow/internal/scaffold/templates"
-	"github.com/kunalkushwaha/agentflow/internal/scaffold/utils"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/scaffold/templates"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/scaffold/utils"
 )
 
-// AgentInfo represents information about an agent including its name and purpose
-type AgentInfo struct {
-	Name        string // User-defined name like "analyzer", "processor"
-	FileName    string // File name like "analyzer.go"
-	DisplayName string // Capitalized name like "Analyzer"
-	Purpose     string // Brief description of the agent's purpose
-	Role        string // Agent role like "collaborative", "sequential", "loop"
-}
-
-// ProjectConfig represents the configuration for creating a new AgentFlow project
-type ProjectConfig struct {
-	Name          string
-	NumAgents     int
-	Provider      string
-	ResponsibleAI bool
-	ErrorHandler  bool
-
-	// MCP configuration
-	MCPEnabled         bool
-	MCPProduction      bool
-	WithCache          bool
-	WithMetrics        bool
-	MCPTools           []string
-	MCPServers         []string
-	CacheBackend       string
-	MetricsPort        int
-	WithLoadBalancer   bool
-	ConnectionPoolSize int
-	RetryPolicy        string
-
-	// Multi-agent orchestration configuration
-	OrchestrationMode    string
-	CollaborativeAgents  []string
-	SequentialAgents     []string
-	LoopAgent            string
-	MaxIterations        int
-	OrchestrationTimeout int
-	FailureThreshold     float64
-	MaxConcurrency       int
-}
+// Use types from the utils package for consistency
+type AgentInfo = utils.AgentInfo
+type ProjectConfig = utils.ProjectConfig
 
 // TemplateData represents the data structure passed to templates
 type TemplateData struct {

--- a/internal/scaffold/generators/project.go
+++ b/internal/scaffold/generators/project.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/kunalkushwaha/agentflow/internal/scaffold"
-	"github.com/kunalkushwaha/agentflow/internal/scaffold/templates"
-	"github.com/kunalkushwaha/agentflow/internal/scaffold/utils"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/scaffold"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/scaffold/templates"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/scaffold/utils"
 )
 
 // ProjectGenerator handles the generation of project structure and main files
@@ -61,7 +61,7 @@ func (g *ProjectGenerator) GenerateProjectStructure(config scaffold.ProjectConfi
 
 // generateGoMod creates the go.mod file
 func (g *ProjectGenerator) generateGoMod(config scaffold.ProjectConfig) error {
-	goModContent := fmt.Sprintf("module %s\n\ngo 1.21\n\nrequire github.com/kunalkushwaha/agentflow %s\n", config.Name, scaffold.AgentFlowVersion)
+	goModContent := fmt.Sprintf("module %s\n\ngo 1.21\n\nrequire github.com/kunalkushwaha/AgenticGoKit %s\n", config.Name, scaffold.AgenticGoKitVersion)
 	goModPath := filepath.Join(config.Name, "go.mod")
 	if err := os.WriteFile(goModPath, []byte(goModContent), 0644); err != nil {
 		return fmt.Errorf("failed to create go.mod: %w", err)

--- a/internal/scaffold/scaffold.go
+++ b/internal/scaffold/scaffold.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"text/template"
 
-	"github.com/kunalkushwaha/agentflow/internal/scaffold/templates"
-	"github.com/kunalkushwaha/agentflow/internal/scaffold/utils"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/scaffold/templates"
+	"github.com/kunalkushwaha/AgenticGoKit/internal/scaffold/utils"
 )
 
 // CreateAgentProject creates a new AgentFlow project (alias for CreateAgentProjectModular)
@@ -80,7 +80,7 @@ func CreateAgentProjectModular(config ProjectConfig) error {
 
 // createGoMod creates the go.mod file
 func createGoMod(config ProjectConfig) error {
-	goModContent := fmt.Sprintf("module %s\n\ngo 1.21\n\nrequire github.com/kunalkushwaha/agentflow %s\n", config.Name, AgentFlowVersion)
+	goModContent := fmt.Sprintf("module %s\n\ngo 1.21\n\nrequire github.com/kunalkushwaha/AgenticGoKit %s\n", config.Name, AgenticGoKitVersion)
 	goModPath := filepath.Join(config.Name, "go.mod")
 	if err := os.WriteFile(goModPath, []byte(goModContent), 0644); err != nil {
 		return fmt.Errorf("failed to create go.mod: %w", err)
@@ -254,30 +254,30 @@ func createReadme(config ProjectConfig) error {
 
 	// Documentation and Resources section
 	content += "## 📚 Documentation & Resources\n\n"
-	content += "### AgentFlow Documentation\n"
-	content += "- **[AgentFlow Documentation](https://github.com/kunalkushwaha/agentflow/tree/main/docs)** - Complete framework documentation\n"
-	content += "- **[Agent Basics Guide](https://github.com/kunalkushwaha/agentflow/blob/main/docs/guides/AgentBasics.md)** - Understanding AgentHandler interface and patterns\n"
-	content += "- **[Configuration Guide](https://github.com/kunalkushwaha/agentflow/blob/main/docs/guides/Configuration.md)** - Managing agentflow.toml and environment setup\n"
-	content += "- **[Examples & Tutorials](https://github.com/kunalkushwaha/agentflow/blob/main/docs/guides/Examples.md)** - Practical examples and code samples\n\n"
+	content += "### AgenticGoKit Documentation\n"
+	content += "- **[AgenticGoKit Documentation](https://github.com/kunalkushwaha/AgenticGoKit/tree/main/docs)** - Complete framework documentation\n"
+	content += "- **[Agent Basics Guide](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/guides/AgentBasics.md)** - Understanding AgentHandler interface and patterns\n"
+	content += "- **[Configuration Guide](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/guides/Configuration.md)** - Managing agentflow.toml and environment setup\n"
+	content += "- **[Examples & Tutorials](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/guides/Examples.md)** - Practical examples and code samples\n\n"
 
 	if config.MemoryEnabled {
 		content += "### Memory & RAG Documentation\n"
-		content += "- **[Memory System Guide](https://github.com/kunalkushwaha/agentflow/blob/main/docs/guides/Memory.md)** - Complete memory implementation guide\n"
-		content += "- **[RAG Configuration Guide](https://github.com/kunalkushwaha/agentflow/blob/main/docs/guides/RAGConfiguration.md)** - RAG configuration and best practices\n"
-		content += "- **[Memory Quick Reference](https://github.com/kunalkushwaha/agentflow/blob/main/docs/memory_quick_reference.md)** - Essential memory API reference\n\n"
+		content += "- **[Memory System Guide](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/guides/Memory.md)** - Complete memory implementation guide\n"
+		content += "- **[RAG Configuration Guide](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/guides/RAGConfiguration.md)** - RAG configuration and best practices\n"
+		content += "- **[Memory Quick Reference](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/memory_quick_reference.md)** - Essential memory API reference\n\n"
 	}
 
 	if config.MCPEnabled {
 		content += "### MCP Integration Documentation\n"
-		content += "- **[Tool Integration Guide](https://github.com/kunalkushwaha/agentflow/blob/main/docs/guides/ToolIntegration.md)** - MCP protocol and dynamic tool discovery\n"
-		content += "- **[Custom Tools Guide](https://github.com/kunalkushwaha/agentflow/blob/main/docs/guides/CustomTools.md)** - Building your own MCP servers\n\n"
+		content += "- **[Tool Integration Guide](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/guides/ToolIntegration.md)** - MCP protocol and dynamic tool discovery\n"
+		content += "- **[Custom Tools Guide](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/guides/CustomTools.md)** - Building your own MCP servers\n\n"
 	}
 
 	content += "### Advanced Topics\n"
-	content += "- **[Multi-Agent Orchestration](https://github.com/kunalkushwaha/agentflow/blob/main/docs/multi_agent_orchestration.md)** - Advanced orchestration patterns and configuration\n"
-	content += "- **[Production Deployment](https://github.com/kunalkushwaha/agentflow/blob/main/docs/guides/Production.md)** - Scaling, monitoring, and best practices\n"
-	content += "- **[Performance Tuning](https://github.com/kunalkushwaha/agentflow/blob/main/docs/guides/Performance.md)** - Optimization and benchmarking\n"
-	content += "- **[Error Handling](https://github.com/kunalkushwaha/agentflow/blob/main/docs/guides/ErrorHandling.md)** - Resilient agent workflows\n\n"
+	content += "- **[Multi-Agent Orchestration](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/multi_agent_orchestration.md)** - Advanced orchestration patterns and configuration\n"
+	content += "- **[Production Deployment](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/guides/Production.md)** - Scaling, monitoring, and best practices\n"
+	content += "- **[Performance Tuning](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/guides/Performance.md)** - Optimization and benchmarking\n"
+	content += "- **[Error Handling](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/guides/ErrorHandling.md)** - Resilient agent workflows\n\n"
 
 	// Troubleshooting section
 	content += "## 🔧 Troubleshooting\n\n"
@@ -315,9 +315,9 @@ func createReadme(config ProjectConfig) error {
 	}
 
 	content += "### Getting Help\n\n"
-	content += "- **[GitHub Issues](https://github.com/kunalkushwaha/agentflow/issues)** - Report bugs and request features\n"
-	content += "- **[Discussions](https://github.com/kunalkushwaha/agentflow/discussions)** - Community support and questions\n"
-	content += "- **[Documentation](https://github.com/kunalkushwaha/agentflow/tree/main/docs)** - Comprehensive guides and API reference\n\n"
+	content += "- **[GitHub Issues](https://github.com/kunalkushwaha/AgenticGoKit/issues)** - Report bugs and request features\n"
+	content += "- **[Discussions](https://github.com/kunalkushwaha/AgenticGoKit/discussions)** - Community support and questions\n"
+	content += "- **[Documentation](https://github.com/kunalkushwaha/AgenticGoKit/tree/main/docs)** - Comprehensive guides and API reference\n\n"
 
 	// Project Structure section
 	content += "## 📁 Project Structure\n\n"
@@ -356,10 +356,10 @@ func createReadme(config ProjectConfig) error {
 		content += "3. **Add Tools**: Configure additional MCP tools for enhanced capabilities\n"
 	}
 	content += fmt.Sprintf("%d. **Scale Up**: Add more agents or modify orchestration patterns as needed\n", 3 + (func() int { count := 0; if config.MemoryEnabled { count++; if config.RAGEnabled { count++ } }; if config.MCPEnabled { count++ }; return count })())
-	content += fmt.Sprintf("%d. **Deploy**: Follow the [Production Guide](https://github.com/kunalkushwaha/agentflow/blob/main/docs/guides/Production.md) for deployment\n\n", 4 + (func() int { count := 0; if config.MemoryEnabled { count++; if config.RAGEnabled { count++ } }; if config.MCPEnabled { count++ }; return count })())
+	content += fmt.Sprintf("%d. **Deploy**: Follow the [Production Guide](https://github.com/kunalkushwaha/AgenticGoKit/blob/main/docs/guides/Production.md) for deployment\n\n", 4 + (func() int { count := 0; if config.MemoryEnabled { count++; if config.RAGEnabled { count++ } }; if config.MCPEnabled { count++ }; return count })())
 
 	content += "---\n\n"
-	content += "*Generated with ❤️ by [AgentFlow](https://github.com/kunalkushwaha/agentflow)*\n"
+	content += "*Generated with ❤️ by [AgenticGoKit](https://github.com/kunalkushwaha/AgenticGoKit)*\n"
 
 	readmePath := filepath.Join(config.Name, "README.md")
 	if err := os.WriteFile(readmePath, []byte(content), 0644); err != nil {

--- a/internal/scaffold/templates/main.go
+++ b/internal/scaffold/templates/main.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/kunalkushwaha/agentflow/core"
+	"github.com/kunalkushwaha/AgenticGoKit/core"
 )
 
 {{if .Config.MemoryEnabled}}


### PR DESCRIPTION
- Update module declaration from github.com/kunalkushwaha/agentflow to github.com/kunalkushwaha/AgenticGoKit
- Update all internal import statements across core, internal, and cmd packages
- Update scaffold templates to generate projects with new repository references
- Update scaffold generator code and rename AgentFlowVersion to AgenticGoKitVersion (v0.3.2)
- Update variable aliases from agentflow to agenticgokit throughout codebase
- Update documentation links and README references to new repository
- Update example projects and test dependencies to use new module name
- Fix OpenAI API endpoint from deprecated v1/completions to v1/chat/completions
- Update test files and helper functions with new repository references
- Verify all functionality works correctly with new repository name

BREAKING CHANGE: Module name changed from github.com/kunalkushwaha/agentflow to github.com/kunalkushwaha/AgenticGoKit