### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kunalkushwaha/AgenticGoKit/security/code-scanning/4](https://github.com/kunalkushwaha/AgenticGoKit/security/code-scanning/4)

To fix the problem, you should add a `permissions` block to the workflow file `.github/workflows/ci.yml`. This block can be added at the top level (applies to all jobs) or to individual jobs if different jobs require different permissions. In this case, since none of the jobs appear to require write access to repository contents, the minimal permission `contents: read` is sufficient and safest. Add the following block immediately after the workflow `name` and before the `on:` block:

```yaml
permissions:
  contents: read
```

This change ensures that the workflow and all jobs within it only have read access to repository contents, adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
