### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-install-scripts.yml
+++ b/.github/workflows/update-install-scripts.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Weekly on Monday at 6 AM UTC
 
+permissions:
+  contents: write
 jobs:
   update-scripts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/kunalkushwaha/AgenticGoKit/security/code-scanning/1](https://github.com/kunalkushwaha/AgenticGoKit/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow checks out code and may commit changes (though it does not push), the minimal required permission is `contents: write` (to allow for possible future pushes or to avoid breaking if a push is added). If you are certain that no pushes will ever occur, you could use `contents: read`, but given the presence of `git commit`, `contents: write` is safer. The `permissions` block should be added at the root level of the workflow file (above `jobs:`) to apply to all jobs unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
